### PR TITLE
Rename bundle class according to Symfony2 conventions

### DIFF
--- a/YllyMediaManagerBundle.php
+++ b/YllyMediaManagerBundle.php
@@ -7,23 +7,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Doctrine\DBAL\Types\Type;
 
-class MediaManagerBundle extends Bundle
+class YllyMediaManagerBundle extends Bundle
 {
 	public function boot()
 	{
 		$em = $this->container->get('doctrine.orm.default_entity_manager');
 		Type::addType('longblob', 'Ylly\MediaManagerBundle\Types\LongBlob');
 		$em->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping('LONGBLOB', 'longblob');
-		
-		
+
+
 		/*$classLoader = new \Doctrine\Common\ClassLoader('Ylly', __DIR__."/Behavior");
         $classLoader->register();
-        
+
         $evm = $em->getEventManager();
-        
-        
+
+
         $fileableListener = new \Ylly\MediaManagerBundle\Behavior\Fileable\FileableListener();
         $evm->addEventSubscriber($fileableListener);*/
-        
+
 	}
 }


### PR DESCRIPTION
It should be prefixed with the vendor name.
It looks like my code editor also trimmed white spaces, which is not a bad thing.
